### PR TITLE
Allow applicationId to be null

### DIFF
--- a/prisma/migrations/20220322193855_make_application_id_nullable/migration.sql
+++ b/prisma/migrations/20220322193855_make_application_id_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Shrtlnk" ALTER COLUMN "applicationId" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ model Shrtlnk {
   key           String        @unique
   url           String
   createdAt     DateTime      @default(now())
-  applicationId String
+  applicationId String?
   application   Application?  @relation(fields: [applicationId], references: [id], onDelete: SetNull)
   loads         ShrtlnkLoad[]
 }


### PR DESCRIPTION
Noticed a bug where applications with shrtlnks could not be deleted, this fixes that.