### PR TITLE
force page reload after register/sign in

### DIFF
--- a/app/routes/developer/register.tsx
+++ b/app/routes/developer/register.tsx
@@ -127,7 +127,7 @@ export default function SignupCard() {
         boxShadow={"lg"}
         p={8}
       >
-        <Form method="post" noValidate>
+        <Form method="post" noValidate reloadDocument>
           <Stack spacing={4}>
             <HStack>
               <Box>

--- a/app/routes/developer/signin.tsx
+++ b/app/routes/developer/signin.tsx
@@ -107,7 +107,7 @@ export default function SimpleCard() {
         boxShadow={"lg"}
         p={8}
       >
-        <Form method="post" noValidate>
+        <Form method="post" noValidate reloadDocument>
           <input
             type="hidden"
             name="redirectTo"

--- a/cypress/integration/dev-portal.ts
+++ b/cypress/integration/dev-portal.ts
@@ -63,6 +63,21 @@ describe("Registering for an account", () => {
     cy.findByText("Create Account").click();
     cy.findByText("Test App");
   });
+
+  it("keeps you signed in after registering", () => {
+    const email = `integration-${new Date().getTime()}@test.com`;
+    cy.findByLabelText("First Name*").clear().type("integration");
+    cy.findByLabelText("Last Name*").clear().type(new Date().toLocaleString());
+    cy.findByLabelText("Email Address*").clear().type(email);
+    cy.findByLabelText("Password*").clear().type("password");
+    cy.findByText("Sign up").click();
+    cy.findByText("Your Applications");
+    cy.findByText("Hey there, integration");
+    cy.findAllByText("Documentation").first().click();
+    cy.findAllByText("My Applications").first().click();
+    cy.findByText("Hey there, integration");
+    cy.task("deleteUser", email);
+  });
 });
 
 describe("Signing into an account", () => {


### PR DESCRIPTION
There was a race condition where the remix client was not setting the session cookie before making the next request. This change tells remix to submit the form with a full page refresh which delegates cookie setting to the browser instead of remix client.